### PR TITLE
Fix typo that make newbie confused

### DIFF
--- a/_pages/5/07.md
+++ b/_pages/5/07.md
@@ -110,21 +110,21 @@ two instructions is the code responsible for adding recoil.
 
 While we could step through this code to identify the instruction, we can
 use a quicker approach. We know that the recoil instruction must modify
-the player's yaw value. After we hit our breakpoint on our weapon firing,
-if we then set a breakpoint on the yaw value, we can continue execution
+the player's pitch value. After we hit our breakpoint on our weapon firing,
+if we then set a breakpoint on the pitch value, we can continue execution
 and wait for the breakpoint to pop. This prevents us from stepping through
 a large amount of code.
 
-It's important that we only set the breakpoint on the yaw value after the
+It's important that we only set the breakpoint on the pitch value after the
 firing code is started. Assault Cube, like many other games, constantly
-writes to the yaw value. If we just set a breakpoint on it without being
+writes to the pitch value. If we just set a breakpoint on it without being
 in the firing code, we will end up in another section of code.
 
-We can locate the address of the yaw value using the same approach
+We can locate the address of the pitch value using the same approach
 discussed in the previous lesson or by searching for it in Cheat Engine.
 After that, set a breakpoint on the start of the firing code at
 `0x46366C`. Then, fire a single shot so the breakpoint pops.
-When it does, set a breakpoint on write on the address of the yaw value.
+When it does, set a breakpoint on write on the address of the pitch value.
 Continue execution and the write breakpoint should pop at the following
 code:
 
@@ -132,13 +132,13 @@ code:
 
 We can see that this code matches the pattern we expected. In this
 particular code, **dword ptr ds:[ebx+0x44]** is responsible
-for holding the player's yaw value. The recoil value is held on the top of
+for holding the player's pitch value. The recoil value is held on the top of
 the FPU stack, which is pointed to by **st0**.
 
 The operation to calculate recoil appears to be composed of several
 instructions. While we could investigate the exact way in which the recoil
 is set, we can skip that process to make a no recoil hack and simply
-prevent the recoil value from being placed in the player's yaw value.
+prevent the recoil value from being placed in the player's pitch value.
 
 The **fstp** instruction is responsible for popping the top
 value off the FPU stack into the provided address. Since we do not want to

--- a/_pages/5/08.md
+++ b/_pages/5/08.md
@@ -148,14 +148,14 @@ can use the same technique as discussed in the [No Recoil](/pages/5/07/) lesson:
 ```c++
 #include <Windows.h>
 
-unsigned char new_bytes[5] = { 0x90, 0x90, 0x90, 0x90, 0x90 };
+unsigned char new_bytes[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 };
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
   DWORD old_protect;
   unsigned char* hook_location = (unsigned char*)0x409FB3;
 
   if (fdwReason == DLL_PROCESS_ATTACH) {
-    VirtualProtect((void*)hook_location, 5, PAGE_EXECUTE_READWRITE, &old_protect);
+    VirtualProtect((void*)hook_location, 6, PAGE_EXECUTE_READWRITE, &old_protect);
     for (int i = 0; i < sizeof(new_bytes); i++) {
       *(hook_location + i) = new_bytes[i];
     }


### PR DESCRIPTION
Hi, I'm very interested in game hacking and luckily I found your tutorial, it's a treasure for me. I love hacking but I'm not familiar with FPS games, so I don't have much knowledge about yaw and pitch. When I learn the "No Recoil" lesson, I tried to find the address and set the breakpoint on "YAW" but never got to 0x45BAAD as the tutorial instructed and it took me a long time to realize that it should be "PITCH" not "YAW". I think we should correct that spelling mistake, thanks anyway! :D